### PR TITLE
added variable and unit proposal

### DIFF
--- a/metacatalog/data/units.csv
+++ b/metacatalog/data/units.csv
@@ -19,6 +19,7 @@ id,name,symbol,si
 18,ohm,ohm,kg*m^2*s^-3*A^-2
 19,siemens,S,kg^-1*m^-2*s^3*A^2
 20,lux,lx,m^-2*cd
+21,relative,-,1
 101,degree Celsius,C,K
 102,milimeter,10^-3*m
 103,mm per day,mm/d,10^-3*m*86400^-1*s^-1

--- a/metacatalog/data/variables.csv
+++ b/metacatalog/data/variables.csv
@@ -11,4 +11,4 @@ id,name,symbol,unit_id,keyword_id
 10,net radiation,Rn,115,5227
 11,gravimetric water content,u,114,5727
 12,volumnetric water content,theta,113,5727
-13,uncertainty,sigma,21,
+13,precision,sigma,21,

--- a/metacatalog/data/variables.csv
+++ b/metacatalog/data/variables.csv
@@ -11,3 +11,4 @@ id,name,symbol,unit_id,keyword_id
 10,net radiation,Rn,115,5227
 11,gravimetric water content,u,114,5727
 12,volumnetric water content,theta,113,5727
+13,uncertainty,sigma,21,


### PR DESCRIPTION
This PR resolves #11 
Basically, a unit of `relative` is added that is used  by the new variable of `uncertainty`. This can be used for use-cases:

* more than one measure of uncertainty needs to be related to a dataset
* the uncertainty information needs additional metadata (has its own entry)

The actual value is then understood as a relative *error* in the unit of the variable, or to be specified more precisely by the connected `metacatalog.Entry`.