### PR TITLE
Adding Sap flow variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ venv.bak/
 # project
 .vscode
 DBNAME
+tutorials

--- a/metacatalog/data/units.csv
+++ b/metacatalog/data/units.csv
@@ -20,7 +20,8 @@ id,name,symbol,si
 19,siemens,S,kg^-1*m^-2*s^3*A^2
 20,lux,lx,m^-2*cd
 21,relative,-,1
-22,mass flux,10^-3*m^3*10^2*m^-2*s*-1
+22,mass flux density per hour,cm^3/cm^2h,10^-3*m^3*10^2*m^-2*3600^-1*s*-1
+23,hour,h,3600*s
 101,degree Celsius,C,K
 102,milimeter,10^-3*m
 103,mm per day,mm/d,10^-3*m*86400^-1*s^-1

--- a/metacatalog/data/units.csv
+++ b/metacatalog/data/units.csv
@@ -20,6 +20,7 @@ id,name,symbol,si
 19,siemens,S,kg^-1*m^-2*s^3*A^2
 20,lux,lx,m^-2*cd
 21,relative,-,1
+22,mass flux,10^-3*m^3*10^2*m^-2*s*-1
 101,degree Celsius,C,K
 102,milimeter,10^-3*m
 103,mm per day,mm/d,10^-3*m*86400^-1*s^-1

--- a/metacatalog/data/variables.csv
+++ b/metacatalog/data/variables.csv
@@ -12,4 +12,4 @@ id,name,symbol,unit_id,keyword_id
 11,gravimetric water content,u,114,5727
 12,volumnetric water content,theta,113,5727
 13,precision,sigma,21,
-14,sap flow,Fm,22
+14,sap flow,Fm,22,7424

--- a/metacatalog/data/variables.csv
+++ b/metacatalog/data/variables.csv
@@ -12,3 +12,4 @@ id,name,symbol,unit_id,keyword_id
 11,gravimetric water content,u,114,5727
 12,volumnetric water content,theta,113,5727
 13,precision,sigma,21,
+14,sap flow,Fm,22


### PR DESCRIPTION
Closes #10 

Actually, the unit of sap flow needs to be converted to follow the metacatalog unit logic.

I see three options here:
a) always transform data to given unit and integrate by time interval between observations. This could be bad, because we change the data and cannot handle gaps properly. Without gaps, data would become more comparable.
b) we keep the unit as it is but do not transform the data. Then any kind of flux in metacatalog is always interpreted as integrated between timesteps in the unit of the variable. So the unit would be per second, but the data integrated to 10min, because the time step in 10min. The uploader would have to assure correctness of data.
c) We add a new sap flow variable with a new unit (different temporal integration window) with each dataset that uses different time steps. 
 
I think b) is the only realistic option and need to document this properly.