### PR TITLE
Details

### DIFF
--- a/alembic/versions/001cf6d1cb6d_details_thesaurus.py
+++ b/alembic/versions/001cf6d1cb6d_details_thesaurus.py
@@ -1,0 +1,24 @@
+"""details_thesaurus
+
+Revision ID: 001cf6d1cb6d
+Revises: b2220bb497cb
+Create Date: 2020-07-07 11:06:06.488381
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '001cf6d1cb6d'
+down_revision = 'b2220bb497cb'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('details', sa.Column('thesaurus_id', sa.Integer, sa.ForeignKey('thesaurus.id')))
+
+
+def downgrade():
+    op.drop_column('details', 'thesaurus_id')

--- a/metacatalog/models/details.py
+++ b/metacatalog/models/details.py
@@ -20,6 +20,11 @@ class Detail(Base):
     text-based tables. A HTML or markdown table can e.g. be appended 
     to the `Entry.abstract` on export.
 
+    Since version 0.1.13, it is possible to link an existing 
+    :class:`Thesaurus <metacatalog.models.Thesaurus>` to the detail.
+    This makes the export to ISO 19115 in princile possible as an 
+    ``MD_MetadataExtensionInformation`` object.
+
     Attributes
     ----------
     id : int
@@ -42,11 +47,16 @@ class Detail(Base):
         :class:`EntryGroup <metacatalog.models.EntryGroup>`. Optional,
         can be omitted, if not applicable.
     thesaurus : metacatalog.models.Thesaurus
-        If the detail :attr:`key` is described in a thesaurus or
+        .. versionadded:: 0.1.13
+        Optional. If the detail :attr:`key` is described in a thesaurus or
         controlled dictionary list, you can link the thesaurus 
         to the detail. Details with thesaurus information are 
         in principle exportable to ISO 19115 using an 
         ``MD_MetadataExtensionInformation``.
+    thesaurus_id : int
+        .. versionadded:: 0.1.13
+        Foreign key of the linked 
+        :class:`Thesaurus <metacatalog.models.Thesaurus>`. 
 
     """
     __tablename__ = 'details'
@@ -82,7 +92,7 @@ class Detail(Base):
         if self.description is not None:
             d['description'] = self.description
 
-        if self.deep:
+        if deep:
             d['entry'] = self.entry.to_dict(deep=False)
         else:
             d['entry_id'] = self.entry.id

--- a/metacatalog/models/details.py
+++ b/metacatalog/models/details.py
@@ -91,4 +91,7 @@ class Detail(Base):
         return d
 
     def __str__(self):
-        return "%s = %s" % (self.key, self.value) 
+        if self.thesaurus is not None:
+            return '%s = %s <%s>' % (self.key, self.value, self.thesaurus.name)
+        else:
+            return "%s = %s" % (self.key, self.value) 


### PR DESCRIPTION
As far as I can see it, we only need the ability to link `Details` to `Thesaurus` information. Then a `MD_MetadataExtensionInformation` can hold and online resource of `thesaurus.url` to be traceable.

Solves #66 and will close #62 as that does not apply anymore. Details with thesaurus information will also close #80 , but an exporter will need to distinguish between details that are described by a thesaurus and the ones that don't.