### PR TITLE
Installation instruction windows

### DIFF
--- a/docs/source/home/install.rst
+++ b/docs/source/home/install.rst
@@ -63,3 +63,10 @@ When using Windows this command can lead to errors and must be changed in this c
 .. code-block:: bash
 
     python -m metacatalog init --connection driver://user:password@host:port/database
+
+
+
+The (standard) connection string could look like this:
+.. code-block:: bash
+
+    python -m metacatalog init --connection postgresql://postgres:\ *yourpassword*\ @localhost:5432/metacatalog

--- a/docs/source/home/install.rst
+++ b/docs/source/home/install.rst
@@ -41,14 +41,11 @@ You can install metacatalog from PyPI
 Create Tables
 -------------
 
-.. note::
-
-    Refer to the CLI command `create <../cli/cli_create.ipynb>`_, `populate <../cli/cli_populate.ipynb>`_ and
-    `init <../cli/cli_init.ipynb>`_ for more detailed information.
+.. note:: Refer to the CLI command `create <../cli/cli_create.ipynb>`_, `populate <../cli/cli_populate.ipynb>`_ and `init <../cli/cli_init.ipynb>`_ for more detailed information.
 
 After the database has been installed, you can use the `metacatalog CLI <../cli/cli.rst>`_
 to create the necessary tables.
-Follow the syntax of the init command and replace *driver*, *user*, *password*, *host* and *database* with your parameters. 
+Follow the syntax of the init command and replace *driver*, *user*, *password*, *host* and *database* with your parameters.
 
 .. code-block:: bash
 

--- a/docs/source/home/install.rst
+++ b/docs/source/home/install.rst
@@ -47,10 +47,15 @@ Create Tables
     `init <../cli/cli_init.ipynb>`_ for more detailed information.
 
 After the database has been installed, you can use the `metacatalog CLI <../cli/cli.rst>`_
-to create the necessary tables:
+to create the necessary tables.
+Follow the syntax of the init command and replace *driver*, *user*, *password*, *host* and *database* with your parameters. 
 
 .. code-block:: bash
 
-    metacatalog init --connection postgresql://user:password@host:port/dbname
+    metacatalog init --connection driver://user:password@host:port/database
 
-As this
+When using Windows this command can lead to errors and must be changed in this case (refer to `metacatalog CLI <../cli/cli.rst>`_):
+
+.. code-block:: bash
+
+    python -m metacatalog init --connection driver://user:password@host:port/database

--- a/docs/source/home/install.rst
+++ b/docs/source/home/install.rst
@@ -41,11 +41,18 @@ You can install metacatalog from PyPI
 Create Tables
 -------------
 
-.. note:: Refer to the CLI command `create <../cli/cli_create.ipynb>`_, `populate <../cli/cli_populate.ipynb>`_ and `init <../cli/cli_init.ipynb>`_ for more detailed information.
+.. note::
+
+    Refer to the CLI command `create <../cli/cli_create.ipynb>`_, `populate <../cli/cli_populate.ipynb>`_ and
+    `init <../cli/cli_init.ipynb>`_ for more detailed information.
 
 After the database has been installed, you can use the `metacatalog CLI <../cli/cli.rst>`_
 to create the necessary tables.
-Follow the syntax of the init command and replace *driver*, *user*, *password*, *host* and *database* with your parameters.
+Follow the syntax of the init command and replace *driver*, *user*, *password*, *host* and *database* with your parameters
+
+.. note::
+
+    All parameters can be accessed in pgAdmin or have been previously set by the user.
 
 .. code-block:: bash
 

--- a/docs/source/home/install.rst
+++ b/docs/source/home/install.rst
@@ -66,7 +66,8 @@ When using Windows this command can lead to errors and must be changed in this c
 
 
 
-The (standard) connection string could look like this:
+The (standard) connection command could look like this:
+
 .. code-block:: bash
 
     python -m metacatalog init --connection postgresql://postgres:\ *yourpassword*\ @localhost:5432/metacatalog

--- a/docs/source/home/install.rst
+++ b/docs/source/home/install.rst
@@ -5,8 +5,10 @@ Installation
 Prerequisites
 -------------
 
-First you need to install PostgreSQL and the PostGIS extension. There are preinstalled binaries
-for windows.
+First you need to install PostgreSQL and the PostGIS extension.
+You can find the PostgreSQL installer for Windows on the official PostgreSQL website.
+Make sure that the stack installer is installed during the PostgreSQL installation process to install the PostGIS extension as well.
+
 On Linux the commands might look similar to:
 
 .. code-block:: bash
@@ -17,9 +19,9 @@ On Linux the commands might look similar to:
 PostGIS will in many cases be a rather outdated version. This is up to now not a big issue, as
 metacatalog uses only a limited amount of spatial functions. Anything > v2.0 should be fine.
 
-Next, you need to install the database and create the extension. The database name should fit
-the one specified in the connection string above (or change the string). You can open a SQL
-console to postgresql or use psql:
+Next, you need to install the database and create the PostGIS extension. In this example, the chosen database name is 'metacatalog'.
+You can create the database and the extension in the GUI application pgAdmin, which is installed together with PostgreSQL or
+you can open a SQL console to postgresql or use psql:
 
 .. code-block:: sql
 
@@ -44,9 +46,11 @@ Create Tables
     Refer to the CLI command `create <../cli/cli_create.ipynb>`_, `populate <../cli/cli_populate.ipynb>`_ and
     `init <../cli/cli_init.ipynb>`_ for more detailed information.
 
-After the database has been installed, you can use the `metacatalog CLI <../cli/cli.rst>`
+After the database has been installed, you can use the `metacatalog CLI <../cli/cli.rst>`_
 to create the necessary tables:
 
 .. code-block:: bash
 
     metacatalog init --connection postgresql://user:password@host:port/dbname
+
+As this


### PR DESCRIPTION
I worked on the installation instruction. 

The instruction was already good, but I think now it should be easier for new users.
Maybe even too much detail in the Create Tables section but I think figuring out the connection string could be the most challenging part for new users.

There is still the problem with the shapely package, I had problems with the package on both my PC and my Laptop. These problems were easily solved by installing shapely. The fix for this bug could be included in the installation instruction, but it would be even better if shapely was installed  correctly along with the metacatalog installation.