### PR TITLE
e2e-Test for partial find behavior

### DIFF
--- a/metacatalog/cmd/find.py
+++ b/metacatalog/cmd/find.py
@@ -42,6 +42,8 @@ def find(args):
     elif entity.lower() == 'groups' or entity.lower() == 'group':
         results = api.find_group(session, **kwargs)
     elif entity.lower() == 'entries' or entity.lower() == 'entry':
+        if args.include_partial:
+            kwargs['include_partial'] = True
         results = api.find_entry(session, **kwargs)
     elif entity.lower() == 'thesaurus':
         results = api.find_thesaurus(session, **kwargs)

--- a/metacatalog/command_line.py
+++ b/metacatalog/command_line.py
@@ -60,6 +60,7 @@ def main():
     find_parser = subparsers.add_parser('find', parents=[default_options], add_help=True, help="Find records in the database on exact matches.")
     find_parser.add_argument('entity', type=str, help="Name of the requested database entity.")
     find_parser.add_argument('--by', type=str, action="append", nargs=2, help="key value pair to be used for finding record(s) in the database. Flag can be used multiple times.")
+    find_parser.add_argument('--include-partial', action="store_true", help="Allow the API to find partial entries.")
     find_parser.add_argument('--json', action="store_true", help="Output the found entities as JSON objects")
     find_parser.add_argument('--stdout', action="store_true", help="Default option. Print the string representation of found entities to StdOut.")
     find_parser.add_argument('--csv', action="store_true", help="Output the found entities as CSV.")

--- a/metacatalog/test/test_export_extension.py
+++ b/metacatalog/test/test_export_extension.py
@@ -56,7 +56,8 @@ def export_to_json(entry: Entry):
     # parse back
     d = json.loads(json_str)
 
-    assert len(d['title']) == 3
+    # there is the partial entry now, which should be found
+    assert len(d['title']) == 4
 
     return True
 


### PR DESCRIPTION
This tests covers a partial entry within a `Composite` entry. With `api.find_entry()` it is not found, but with `api.find_entry(include_partial=True) it is found.

Closes #151

For the CLI:
- [x] add the `--include-partial` flag to find CLI