### PR TITLE
add merge behavior

### DIFF
--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -329,7 +329,7 @@ class ImmutableResultSet:
         # build the output dictionary
         return {key: self.get(key) for key in keys}
 
-    def get_data(self, verbose=False, **kwargs) -> dict:
+    def get_data(self, verbose=False, merge=False, **kwargs) -> dict:
         """
         Return the data as a checksum indexed dict
         """
@@ -380,4 +380,34 @@ class ImmutableResultSet:
                 elif len(unmerged) > 0:
                     data[member.checksum] = unmerged
         
-        return data
+        # Composites always try to merge
+        if self.group is not None and self.group.type.name == 'Composite':
+            merge = True
+
+        # handle merging
+        out = dict()
+        if merge:
+            all_data = pd.DataFrame()
+            unmerged = {}
+            
+            # merge everything that is a DataFrame
+            for checksum, dat in data.items():
+                if isinstance(dat, pd.DataFrame):
+                    all_data = pd.merge(all_data, dat, left_index=True, right_index=True, how='outer')
+                else:
+                    unmerged.update({checksum: dat})
+            
+            # specify return type
+            if len(unmerged.keys()) == 0 and not all_data.empty:
+                out = all_data
+            elif len(unmerged.keys()) > 0 and not all_data.emtpy:
+                out = dict(unmerged=unmerged, merged=all_data)
+            elif len(unmerged.keys()) > 0 and all_data.empty:
+                out = unmerged
+            else:
+                out = None
+        else:
+            out = data
+        
+        # return
+        return out

--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -405,7 +405,7 @@ class ImmutableResultSet:
             elif len(unmerged.keys()) > 0 and all_data.empty:
                 out = unmerged
             else:
-                out = None
+                out = dict()
         else:
             out = data
         


### PR DESCRIPTION
This PR closes #156 

Now the `ImmutableResultSet.get_data` method automatically merges Composite datasets. For non-compisites, the merge can be requested by the `merge=True` attribute.

In a first test it worked great for the Eddy composite:

![image](https://user-images.githubusercontent.com/2826034/123386254-c0b79700-d596-11eb-98e4-b25ebb1e6de0.png)

Note the shape of the output DataFrame.

@AlexDo1 can you pull this branch and run it on the updated Eddy branch in scripts, which does create the composite. If everything works fine for you, you can approve this PR. 
