### PR TITLE
using pd.concat() instead of pd.merge()

### DIFF
--- a/metacatalog/test/test_array_type_data.py
+++ b/metacatalog/test/test_array_type_data.py
@@ -278,7 +278,7 @@ def add_split_dataset(session):
     assert_array_almost_equal(data.values, recovered_data)
 
     # Split datasets are concatenated row-wise (pd.concat) -> only one column
-    assert db_data.shape == (350, 1)
+    assert db_data[checksum].shape == (350, 1)
 
     return True
 

--- a/metacatalog/test/test_array_type_data.py
+++ b/metacatalog/test/test_array_type_data.py
@@ -311,7 +311,7 @@ def add_composite_dataset(session):
     # recover data
     db_data = result.get_data()
     
-    # Composite datasets are merged column-wise (pd.merge) -> keep columns
+    # Composite datasets are merged column-wise (pd.merge) -> keep columns and maximal number of rows
     assert db_data.shape == (352, 2)
     assert list(db_data.columns) == ['air_temperature', 'soil_temperature']
 

--- a/metacatalog/test/test_array_type_data.py
+++ b/metacatalog/test/test_array_type_data.py
@@ -287,7 +287,7 @@ def add_composite_dataset(session):
     data_left = pd.DataFrame(data={'value': np.random.normal(10, 1, size=350), 'tstamp': pd.date_range('201309241100', periods=350, freq='15min')})
     data_left.set_index('tstamp', inplace=True)
 
-    data_right = pd.DataFrame(data={'value': np.random.normal(10, 1, size=352), 'tstamp': pd.date_range('201309241100', periods=350, freq='15min')})
+    data_right = pd.DataFrame(data={'value': np.random.normal(10, 1, size=352), 'tstamp': pd.date_range('201309241100', periods=352, freq='15min')})
     data_right.set_index('tstamp', inplace=True)
 
     # add two entries as split datasets

--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -393,12 +393,27 @@ class ImmutableResultSet:
             all_data = pd.DataFrame()
             unmerged = {}
             
-            # merge everything that is a DataFrame
-            for checksum, dat in data.items():
-                if isinstance(dat, pd.DataFrame):
-                    all_data = pd.concat([all_data, dat])
-                else:
-                    unmerged.update({checksum: dat})
+            # Composite: merge everything that is a DataFrame
+            if self.group is not None and self.group.type.name == 'Composite':
+                for checksum, dat in data.items():
+                    if isinstance(dat, pd.DataFrame):
+                        all_data = pd.merge(all_data, dat, left_index=True, right_index=True, how='outer')
+                    else:
+                        unmerged.update({checksum: dat})
+            # Split dataset: concat everything that is a DataFrame
+            elif self.group is not None and self.group.type.name == 'Split dataset':
+                for checksum, dat in data.items():
+                    if isinstance(dat, pd.DataFrame):
+                        all_data = pd.concat([all_data, dat])
+                    else:
+                        unmerged.update({checksum: dat})
+            # other EntryGroup types?
+            else:
+                for checksum, dat in data.items():
+                    if isinstance(dat, pd.DataFrame):
+                        all_data = pd.merge(all_data, dat, left_index=True, right_index=True, how='outer')
+                    else:
+                        unmerged.update({checksum: dat})
             
             # specify return type
             if len(unmerged.keys()) == 0 and not all_data.empty:

--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -383,8 +383,8 @@ class ImmutableResultSet:
                 elif len(unmerged) > 0:
                     data[member.checksum] = unmerged
         
-        # Composites always try to merge
-        if self.group is not None and self.group.type.name == 'Composite':
+        # Composites and Split datasets always try to merge
+        if self.group is not None and self.group.type.name ('Composite', 'Split dataset'):
             merge = True
 
         # handle merging
@@ -396,7 +396,7 @@ class ImmutableResultSet:
             # merge everything that is a DataFrame
             for checksum, dat in data.items():
                 if isinstance(dat, pd.DataFrame):
-                    all_data = pd.merge(all_data, dat, left_index=True, right_index=True, how='outer')
+                    all_data = pd.concat([all_data, dat])
                 else:
                     unmerged.update({checksum: dat})
             

--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -384,7 +384,7 @@ class ImmutableResultSet:
                     data[member.checksum] = unmerged
         
         # Composites and Split datasets always try to merge
-        if self.group is not None and self.group.type.name ('Composite', 'Split dataset'):
+        if self.group is not None and self.group.type.name in ('Composite', 'Split dataset'):
             merge = True
 
         # handle merging


### PR DESCRIPTION
Always merge Split datasets additionally.

The default parameters of [pd.concat()](https://pandas.pydata.org/docs/reference/api/pandas.concat.html) should fit our use case.