### PR TITLE
update datasource after setting data_names

### DIFF
--- a/metacatalog/ext/io/importer.py
+++ b/metacatalog/ext/io/importer.py
@@ -84,6 +84,8 @@ def import_to_internal_table(entry, datasource, data, precision=None, force_data
         datasource.data_names = data_columns
     else:
         datasource.data_names = entry.variable.column_names
+    # update datasource
+    __update_datasource(datasource)
 
     # get the path / table name into which the data should be imported
     if datasource.path is None:


### PR DESCRIPTION
When fixing the tests in #159 I noticed that `datasource.data_names` was `[Null]` for the last datasource added.

This PR fixes this bug by always updating the datasource when importing data.

@mmaelicke should I open pull requests for small bugfixes like this or should I just push directly to master next time?