### PR TITLE
rebuild entrypoint

### DIFF
--- a/metacatalog/metacatalog
+++ b/metacatalog/metacatalog
@@ -1,6 +1,0 @@
-from metacatalog.command_line import main
-
-if __name__=='__main__':
-    main()
-
-

--- a/setup.py
+++ b/setup.py
@@ -112,13 +112,14 @@ setup(
     long_description=readme(),
     long_description_content_type="text/markdown",
     packages=find_packages(),
-    scripts=['metacatalog/metacatalog'],
     cmdclass={
         'develop': PostDevelopCommand,
         'install': PostInstallCommand
     },
     entrypoints={
-        'console_scripts': ['metacatalog = metacatalog.command_line:main']
+        'console_scripts': [
+            'metacatalog = metacatalog.command_line:main'
+        ]
     },
     include_package_data=True,
     zip_safe=False

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ setup(
         'develop': PostDevelopCommand,
         'install': PostInstallCommand
     },
-    entrypoints={
+    entry_points={
         'console_scripts': [
             'metacatalog = metacatalog.command_line:main'
         ]


### PR DESCRIPTION
closes #187 

@AlexDo1, @elnazazmi this pull request should resolve #187 and make metacatalog install without issues on all systems. Not sure if this is solved yet, maybe we need to rebuild `command_line.py` in parts.

You can build the code from this branch using: `python -m build` in the root (after to pip installed build) and then install the created release from the local `./dist/metacatalog-0.6.8.tar.gz` or whatever it's called like:

```
# create new venv
# cd ./metacatalog
python -m build
pip install ./dist/metacatalog-0.99.0.tar.gz
```
To make sure you bypass other metacatalog version cached by pip, either clean the cache or set the version to something like 0.99.0 and package then. 

After install, the metacatalog cli should be available within the virtual environment. 