### PR TITLE
variable.to_dict() only include keyword if exists

### DIFF
--- a/metacatalog/models/variable.py
+++ b/metacatalog/models/variable.py
@@ -151,14 +151,12 @@ class Variable(Base):
             name=self.name,
             symbol=self.symbol,
             unit=self.unit.to_dict(deep=False),
-            column_names=self.column_names,
-            keyword=self.keyword.to_dict(deep=False) if self.keyword else None
+            column_names=self.column_names
         )
 
         # set optionals
-        for attr in ('keyword'):
-            if hasattr(self, attr) and getattr(self, attr) is not None:
-                d[attr] = getattr(self, attr).to_dict(deep=False)
+        if self.keyword:
+            d['keyword'] = self.keyword.to_dict(deep=False) 
 
         # lazy loading
         if deep:

--- a/metacatalog/models/variable.py
+++ b/metacatalog/models/variable.py
@@ -155,8 +155,9 @@ class Variable(Base):
         )
 
         # set optionals
-        if self.keyword:
-            d['keyword'] = self.keyword.to_dict(deep=False) 
+        for attr in ['keyword']:
+            if hasattr(self, attr) and getattr(self, attr) is not None:
+                d[attr] = getattr(self, attr).to_dict(deep=False)
 
         # lazy loading
         if deep:

--- a/metacatalog/models/variable.py
+++ b/metacatalog/models/variable.py
@@ -152,7 +152,7 @@ class Variable(Base):
             symbol=self.symbol,
             unit=self.unit.to_dict(deep=False),
             column_names=self.column_names,
-            keyword=self.keyword.to_dict(deep=False)
+            keyword=self.keyword.to_dict(deep=False) if self.keyword else None
         )
 
         # set optionals


### PR DESCRIPTION
Only include `keyword.to_dict()` in `variable.to_dict()` if a keyword is linked to the variable (without that we get an Exception).

@mmaelicke is it okay to have variables that are not linked to a keyword / thesaurus? I somehow remember you said that we always want to link a keyword to the variables.