### PR TITLE
Include top-level detail of nested details

### DIFF
--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -528,7 +528,7 @@ class Entry(Base):
             if isinstance(detail['value'], dict):
                 # include top-level detail of nested detail
                 details[key] = detail.copy()
-                details[key]['value'] = 'nested'
+                details[key]['value'] = '-'
                 # go for nested details
                 for k, v in detail['value'].items():
                     expand = {

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -524,7 +524,12 @@ class Entry(Base):
         # get the details
         details = dict()
         for key, detail in self.details_dict(full=True).items():
+            # nested details
             if isinstance(detail['value'], dict):
+                # include top-level detail of nested detail
+                details[key] = detail.copy()
+                details[key]['value'] = 'nested'
+                # go for nested details
                 for k, v in detail['value'].items():
                     expand = {
                         f'{key}.{k}': dict(

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -535,7 +535,7 @@ class Entry(Base):
                         f'{key}.{k}': dict(
                             value=v,
                             id=detail['id'],
-                            key=detail['key'],
+                            key=f"{key}.{k}",
                             stem=detail['stem'],
                             entry_id=detail['entry_id'],
                             entry_uuid=detail['entry_uuid']


### PR DESCRIPTION
This PR makes `Entry.details_table()` include the top-level detail of nested details, like in the example below (row `foo` was missing):

![Bildschirmfoto vom 2023-01-26 16-43-43](https://user-images.githubusercontent.com/23619690/214880854-56d4ac81-d7f2-411d-943f-383014b28254.png)

For `value` I just used `'nested'` instead of the nested details, but I think this is not perfect. Even something like `'nested details'` would be better. @mmaelicke do you have any suggestions?

Closes #237 