### PR TITLE
Drop field Entry.geom

### DIFF
--- a/metacatalog/db/revisions/__init__.py
+++ b/metacatalog/db/revisions/__init__.py
@@ -13,6 +13,7 @@ from . import (
     rev11,
     rev12,
     rev13,
+    rev14,
 )
 
 revisions = {
@@ -30,4 +31,5 @@ revisions = {
     11: rev11,
     12: rev12,
     13: rev13,
+    14: rev14,
 }

--- a/metacatalog/db/revisions/rev14.py
+++ b/metacatalog/db/revisions/rev14.py
@@ -1,0 +1,42 @@
+"""
+Metacatalog database revision
+-----------------------------
+date: 2023-01-27T17:10:15.164557
+
+revision #14
+
+Drop deprecated column entries.geom
+
+"""
+from sqlalchemy.orm import Session
+from metacatalog import api, models
+
+UPGRADE_SQL = """
+-- drop column entries.geom
+ALTER TABLE entries
+DROP COLUMN geom;
+COMMIT;
+"""
+
+DOWNGRADE_SQL = """
+-- add column entry.geom
+ALTER TABLE entries
+ADD geom geometry(Geometry,4326);
+COMMIT;
+"""
+
+# define the upgrade function
+def upgrade(session: Session):
+    print('run update')
+    # drop column entries.geom
+    with session.bind.connect() as con:
+        con.execute(UPGRADE_SQL)
+
+
+# define the downgrade function
+def downgrade(session: Session):
+    print('run downgrade')
+    # add column entries.geom
+    with session.bind.connect() as con:
+        con.execute(DOWNGRADE_SQL)
+

--- a/metacatalog/db/views/locations.sql
+++ b/metacatalog/db/views/locations.sql
@@ -1,28 +1,26 @@
---CREATE OR REPLACE VIEW locations AS
+CREATE OR REPLACE VIEW locations AS
 select 
-	st_asewkt(t.point_location),
 	t.*,
 	st_area(t.geom::geography) as "area_sqm"
 from 
 (SELECT 
 entries.id,
-	case when entries.location is not null then
-		entries.location
-	else
-		case when spatial_scales.extent is not null then
-			st_centroid(spatial_scales.extent)
-		else 
-			null::geometry
-		end
-	end  
-	as point_location
-	,
+case when entries.location is not null then
+	entries.location
+else
 	case when spatial_scales.extent is not null then
-		spatial_scales.extent
+		st_centroid(spatial_scales.extent)
 	else 
-		entries.location
-	end 
- 	as "geom"
+		null::geometry
+	end
+end  
+as point_location,
+case when spatial_scales.extent is not null then
+	spatial_scales.extent
+else 
+	entries.location
+end 
+as "geom"
 FROM entries
 LEFT JOIN datasources ON entries.datasource_id = datasources.id
 LEFT JOIN spatial_scales ON spatial_scales.id = datasources.spatial_scale_id

--- a/metacatalog/db/views/locations.sql
+++ b/metacatalog/db/views/locations.sql
@@ -1,4 +1,4 @@
---CREATE OR REPLACE VIEW locations_realdata AS
+--CREATE OR REPLACE VIEW locations AS
 select 
 	st_asewkt(t.point_location),
 	t.*,
@@ -8,28 +8,20 @@ from
 entries.id,
 	case when entries.location is not null then
 		entries.location
-	else 
+	else
 		case when spatial_scales.extent is not null then
 			st_centroid(spatial_scales.extent)
 		else 
- 			case when entries.geom is not null then
- 				st_centroid(entries.geom)
- 			else
-				null::geometry
- 			end
+			null::geometry
 		end
 	end  
 	as point_location
 	,
- 	case when entries.geom is not null then
- 		entries.geom
- 	else
-		case when spatial_scales.extent is not null then
-			spatial_scales.extent
-		else 
-			entries.location
-		end 
-	end
+	case when spatial_scales.extent is not null then
+		spatial_scales.extent
+	else 
+		entries.location
+	end 
  	as "geom"
 FROM entries
 LEFT JOIN datasources ON entries.datasource_id = datasources.id

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -77,23 +77,10 @@ class Entry(Base):
 
         The location as a POINT Geometry in unprojected WGS84 (EPSG: 4326).
         The location is primarily used to show all Entry objects on a map, or
-        perform geo-searches. If the data-source needs to store more complex
-        Geometries, you can use the ``geom`` argument.
+        perform geo-searches.
         The location can be passed as WKT or a tuple of (x, y) coordinates.
         Note that it will be returned and stored as WKB. The output value will
         be reworked in a future release
-    geom : str
-        .. deprecated:: 0.1.11
-
-            The geom attribute will be reomved with a future version
-
-        .. warning::
-
-            The geom attribute is completely untested so far and might be
-            reworked or removed in a future release
-            It takes a WKT of any kind of OGC-conform Geometry. The return value
-            will be the same Geometry as WKB.
-
     creation : datetime.datetime
         Following the ISO19115 the *creation* date is referring to the creation
         date of the **data resource** described by the Entry, not the Entry
@@ -182,7 +169,6 @@ class Entry(Base):
     abstract = Column(String)
     external_id = Column(String)
     location = Column(Geometry(geometry_type='POINT', srid=4326), nullable=True)
-    geom = Column(Geometry)
     version = Column(Integer, default=1, nullable=False)
     latest_version_id = Column(Integer, ForeignKey('entries.id'), nullable=True)
     is_partial = Column(Boolean, default=False, nullable=False)
@@ -338,7 +324,6 @@ class Entry(Base):
             variable=variable_id,
             abstract=data.get('abstract'),
             external_id=data.get('external_id'),
-            geom=data.get('geom'),
             license=license_id,
             embargo=data.get('embargo', False)
         )


### PR DESCRIPTION
With this PR, we drop the field `Entries.geom`, which is deprecated since version `0.1.11`.  
The PR also includes a database revision and an update of the View `locations`, which does not use the `geom` field anymore.

Closes #190 

@AlexDo1: Just a reminder to execute the db revision in the vforwater database and update the locations View.