### PR TITLE
fix nm relation Entry-Keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ venv.bak/
 DBNAME
 tutorials
 Playground.ipynb
+Test.ipynb
 
 # macOS .DS_Store
 .DS_Store

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -187,7 +187,7 @@ class Entry(Base):
 
     # relationships
     contributors = relationship("PersonAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
-    keywords = relationship("KeywordAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
+    keywords = relationship("Keyword", back_populates='tagged_entries', secondary="nm_keywords_entries")
     license = relationship("License", back_populates='entries')
     variable = relationship("Variable", back_populates='entries')
     datasource = relationship("DataSource", back_populates='entries', cascade='all, delete, delete-orphan', single_parent=True)

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -5,11 +5,13 @@ one type of environmental variable. It can hold a reference and interface to the
 If a supported data format is used, Entry can load the data.
 
 """
+from typing import List, Dict
 from datetime import datetime as dt
 import hashlib
 import json
 from dateutil.relativedelta import relativedelta as rd
 from uuid import uuid4
+import warnings
 
 from sqlalchemy import Column, ForeignKey, event
 from sqlalchemy import Integer, String, Boolean, DateTime
@@ -462,25 +464,43 @@ class Entry(Base):
     def location_shape(self, shape):
         self.location = from_shape(shape)
 
-    def plain_keywords_list(self):
+    def keyword_list(self) -> List[str]:
+        """
+        List of tagged keywords associated to this instance. 
+        The keywords are related via the association table.
+
+        """
+        # keywords
+        return [kw.path() for kw in self.keywords]
+
+    def plain_keywords_list(self) -> List[str]:
         """
         Returns list of controlled keywords associated with this
         instance of meta data.
-        If there are any associated values or alias of the given
-        keywords, use the keywords_dict function
+        The List only includes the full path
 
         """
-        return [kw.keyword.path() for kw in self.keywords]
+        warnings.warn("Entry.plain_keyword_list is deprecated since 0.7.3, use Entry.keyword_list instead.", category=DeprecationWarning)
 
-    def plain_keywords_dict(self):
-        return [kw.keyword.to_dict() for kw in self.keywords]
+        return self.keyword_list()
+
+    def plain_keywords_dict(self) -> List[Dict[str, str]]:
+        """
+        Get a list of dictionaries containing a dict representation
+        of each associated keyword to this Entry.
+
+        """
+        warnings.warn("plain_keywords_dict is deprecated. Use [k.to_dict() for k in Entry.keywords] instead.", category=DeprecationWarning)
+        return [kw.to_dict() for kw in self.keywords]
 
     def keywords_dict(self):
+        """
+        """
+        warnings.warn("keywords_dict is deprecated and will be removed with a future release", category=DeprecationWarning)
         return [
             dict(
-                path=kw.keyword.full_path,
-                alias=kw.alias,
-                value=kw.associated_value
+                path=kw.full_path,
+                value=kw.value
             ) for kw in self.keywords
         ]
 

--- a/metacatalog/models/keyword.py
+++ b/metacatalog/models/keyword.py
@@ -191,7 +191,7 @@ class Keyword(Base):
 
     # relationships
     children = relationship("Keyword", backref=backref('parent', remote_side=[id]))
-    tagged_entries = relationship("KeywordAssociation", back_populates='keyword')
+    tagged_entries = relationship("Entry", secondary="nm_keywords_entries", back_populates='keywords')
     thesaurusName = relationship("Thesaurus", back_populates="keywords")
 
     def path(self):
@@ -276,8 +276,8 @@ class KeywordAssociation(Base):
     entry_id = Column(Integer, ForeignKey('entries.id'), primary_key=True)
 
     # relationships
-    keyword = relationship("Keyword", back_populates='tagged_entries')
-    entry = relationship("Entry", back_populates='keywords')
+    #keyword = relationship("Keyword", viewonly=True)#, back_populates='tagged_entries')
+    #entry = relationship("Entry", viewonly=True)#, back_populates='keywords')
 
     def __str__(self):
         return "<Entry ID=%d> tagged %s" % (self.entry.id, self.keyword.value)


### PR DESCRIPTION
closes #236 

@AlexDo1 , the relationship is fixed and `Entry.keywords` actually returns a list of `metacatalog.models.Keyword` instances.  This fix so far also breaks all methods on `Entry` that access the keywords and possibly also the API functions accessing keywords, as these all operated on the association objects.
I will go through the code and fix them one-by-one and hope that I find all references.