### PR TITLE
Future warnings for find api

### DIFF
--- a/metacatalog/api/find.py
+++ b/metacatalog/api/find.py
@@ -786,8 +786,9 @@ def find_entry(session,
     external_id=None, 
     version='latest', 
     project=None, 
-    author=None, 
-    contributor=None, 
+    author=None,
+    coauthor=None,
+    contributor=None,
     keywords=None, 
     details=None,
     include_partial=False,
@@ -816,6 +817,16 @@ def find_entry(session,
         partial Entries. This does only make sense in combination
         with ``as_result=True``, to lazy-load the complete record.
 
+    .. versionchanged:: 0.7.4
+
+        New arugment :attr:`coauthor` introduced, which is a functional
+        replacement for the now deprecated 'contributor' argument.
+
+    .. deprecated:: 0.7.4
+
+        The contributor keyword is deprecated and will change its
+        behavior in a future release. Use the new :attr:`coauthor`
+        argument from now on. 
 
     Parameters
     ----------
@@ -869,7 +880,7 @@ def find_entry(session,
         If None, all version are integrated.
     project : int, str
         .. versionadded:: 0.2.2
-
+`
         The project can be a :class:`EntryGroup <metacatalog.models.EntryGroup>` of
         :class:`EntryGroupType.name=='Project' <metacatalog.models.EntryGroupType>`,
         its id (int) or title (str)
@@ -878,10 +889,22 @@ def find_entry(session,
 
         The author can be a :class:`Person <metacatalog.models.Person>`,
         his id (int) or name (str). A string argument will match first and last
-        names. The author is only the first author. For other contributors see
-        :attr:`contributor`.
+        names. The author is only the first author. For other coauthor see
+        :attr:`coauthor`.
+    coauthor : int ,str
+        .. versionadded:: 0.7.4
+
+        The coauthor can be a :class:`Person <metacatalog.models.Person>`,
+        his id (int) or name (str). A string argument will match first and last
+        names. A  co author is anyone associated as first or co-author. For
+        first author only, see :attr:`author`.
     contributor : int, str
         .. versionadded:: 0.2.2
+
+        .. deprecated:: 0.7.4
+
+            This argument will change its behavior with a future release.
+            Use :attr:`coauthor` as a repalcement.
 
         The contributor can be a :class:`Person <metacatalog.models.Person>`,
         his id (int) or name (str). A string argument will match first and last
@@ -1040,10 +1063,13 @@ def find_entry(session,
             raise AttributeError('author has to be int or str')
 
     # contributor
-    if contributor is not None:
+    if contributor is not None or coauthor is not None:
 
-        if not os.getenv('METACATALOG_SUPRESS_WARN', False):
+        # TODO clean this all up when the contributor behavior is changed
+        if not os.getenv('METACATALOG_SUPRESS_WARN', False) and contributor is not None:
             warnings.warn("The contributor argument will change with a future release. Contributors will be kept, but filter for **any** associated person with a future release. If you want to keep the current behavior, use the authors argument. To supress this warning set the METACATALOG_SUPRESS_WARN environment variable.", FutureWarning)
+        if coauthor is not None:
+            contributor = coauthor
 
         if isinstance(contributor, models.Person):
             contributor = contributor.id

--- a/metacatalog/api/find.py
+++ b/metacatalog/api/find.py
@@ -6,6 +6,9 @@ At the current stage, the following objects can be found by a FIND operation:
 * keywords
 
 """
+import os
+import warnings
+
 import numpy as np
 from sqlalchemy.sql.elements import BinaryExpression
 from sqlalchemy.orm.attributes import InstrumentedAttribute
@@ -1038,14 +1041,18 @@ def find_entry(session,
 
     # contributor
     if contributor is not None:
+
+        if not os.getenv('METACATALOG_SUPRESS_WARN', False):
+            warnings.warn("The contributor argument will change with a future release. Contributors will be kept, but filter for **any** associated person with a future release. If you want to keep the current behavior, use the authors argument. To supress this warning set the METACATALOG_SUPRESS_WARN environment variable.", FutureWarning)
+
         if isinstance(contributor, models.Person):
             contributor = contributor.id
         if isinstance(contributor, int):
             join = query.join(models.PersonAssociation).join(models.PersonRole).join(models.Person)
-            query = join.filter(models.PersonRole.name.in_('author', 'coAuthor')).filter(models.Person.id==contributor)
+            query = join.filter(models.PersonRole.name.in_(['author', 'coAuthor'])).filter(models.Person.id==contributor)
         elif isinstance(contributor, str):
             join = query.join(models.PersonAssociation).join(models.PersonRole).join(models.Person)
-            query = join.filter(models.PersonRole.name.in_('author', 'coAuthor')).filter(
+            query = join.filter(models.PersonRole.name.in_(['author', 'coAuthor'])).filter(
                 (_match(models.Person.first_name, contributor)) | (_match(models.Person.last_name, contributor))
             )
         else:

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -8,6 +8,7 @@ If a supported data format is used, Entry can load the data.
 from typing import List, Dict, TYPE_CHECKING
 if TYPE_CHECKING:
     from metacatalog.models import License, PersonAssociation, Variable, EntryGroup, Keyword, Detail, DataSource, PersonRole
+import os
 from datetime import datetime as dt
 import hashlib
 import json
@@ -312,6 +313,8 @@ class Entry(Base):
         Currently, uploading data sources and data records is not supported.
 
         """
+        if not os.getenv('METACATALOG_SUPRESS_WARN', False):
+            warnings.warn("With a future release, the Entry.from_dict method will not create Entries in the database automatically, but instatiate a model. To supress this warning set the METACATALOG_SUPRESS_WARN environment variable.", FutureWarning)
         if 'id' in data:
             raise NotImplementedError('Updating an Entry is not yet supported.')
         

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -5,7 +5,9 @@ one type of environmental variable. It can hold a reference and interface to the
 If a supported data format is used, Entry can load the data.
 
 """
-from typing import List, Dict
+from typing import List, Dict, TYPE_CHECKING
+if TYPE_CHECKING:
+    from metacatalog.models import License, PersonAssociation, Variable, EntryGroup, Keyword, Detail, DataSource
 from datetime import datetime as dt
 import hashlib
 import json
@@ -188,14 +190,14 @@ class Entry(Base):
     lastUpdate = Column(DateTime, default=dt.utcnow, onupdate=dt.utcnow)
 
     # relationships
-    contributors: List[models.PersonAssociation] = relationship("PersonAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
-    keywords: List[models.Keyword] = relationship("Keyword", back_populates='tagged_entries', secondary="nm_keywords_entries")
-    license: models.License = relationship("License", back_populates='entries')
-    variable: models.Variable = relationship("Variable", back_populates='entries')
-    datasource: models.DataSource = relationship("DataSource", back_populates='entries', cascade='all, delete, delete-orphan', single_parent=True)
+    contributors: List[PersonAssociation] = relationship("PersonAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
+    keywords: List[Keyword] = relationship("Keyword", back_populates='tagged_entries', secondary="nm_keywords_entries")
+    license: License = relationship("License", back_populates='entries')
+    variable: Variable = relationship("Variable", back_populates='entries')
+    datasource: DataSource = relationship("DataSource", back_populates='entries', cascade='all, delete, delete-orphan', single_parent=True)
     other_versions = relationship("Entry", backref=backref('latest_version', remote_side=[id]))
-    associated_groups: List[models.EntryGroup] = relationship("EntryGroup", secondary="nm_entrygroups", back_populates='entries')
-    details: List[models.Detail] = relationship("Detail", back_populates='entry')
+    associated_groups: List[EntryGroup] = relationship("EntryGroup", secondary="nm_entrygroups", back_populates='entries')
+    details: List[Detail] = relationship("Detail", back_populates='entry')
 
     # extensions
     io_extension = None

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -188,14 +188,14 @@ class Entry(Base):
     lastUpdate = Column(DateTime, default=dt.utcnow, onupdate=dt.utcnow)
 
     # relationships
-    contributors = relationship("PersonAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
-    keywords = relationship("Keyword", back_populates='tagged_entries', secondary="nm_keywords_entries")
-    license = relationship("License", back_populates='entries')
-    variable = relationship("Variable", back_populates='entries')
-    datasource = relationship("DataSource", back_populates='entries', cascade='all, delete, delete-orphan', single_parent=True)
+    contributors: List[models.PersonAssociation] = relationship("PersonAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
+    keywords: List[models.Keyword] = relationship("Keyword", back_populates='tagged_entries', secondary="nm_keywords_entries")
+    license: models.License = relationship("License", back_populates='entries')
+    variable: models.Variable = relationship("Variable", back_populates='entries')
+    datasource: models.DataSource = relationship("DataSource", back_populates='entries', cascade='all, delete, delete-orphan', single_parent=True)
     other_versions = relationship("Entry", backref=backref('latest_version', remote_side=[id]))
-    associated_groups = relationship("EntryGroup", secondary="nm_entrygroups", back_populates='entries')
-    details = relationship("Detail", back_populates='entry')
+    associated_groups: List[models.EntryGroup] = relationship("EntryGroup", secondary="nm_entrygroups", back_populates='entries')
+    details: List[models.Detail] = relationship("Detail", back_populates='entry')
 
     # extensions
     io_extension = None
@@ -253,6 +253,15 @@ class Entry(Base):
         for attr in ('abstract', 'external_id','comment', 'citation'):
             if hasattr(self, attr) and getattr(self, attr) is not None:
                 d[attr] = getattr(self, attr)
+
+        # add contributors, that are not author or coAuthor
+        for pa in self.contributors:
+            role: str = pa.role.name
+            if role.lower() not in ['author', 'conauthor']:
+                if not hasattr(d, role):
+                    d[role] = [pa.person.to_dict(deep=False)]
+                else:
+                    d[role].append(pa.person.to_dict(deep=False))
 
         # lazy loading
         if deep:

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -286,7 +286,7 @@ class Entry(Base):
         return out
 
     @classmethod
-    def from_dict(cls, data: dict, session: Session) -> 'Entry':
+    def from_dict(cls, session: Session, data: dict) -> 'Entry':
         """
         Create a *new* Entry in the database from the given dict.
 

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -190,14 +190,14 @@ class Entry(Base):
     lastUpdate = Column(DateTime, default=dt.utcnow, onupdate=dt.utcnow)
 
     # relationships
-    contributors: List[PersonAssociation] = relationship("PersonAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
-    keywords: List[Keyword] = relationship("Keyword", back_populates='tagged_entries', secondary="nm_keywords_entries")
-    license: License = relationship("License", back_populates='entries')
-    variable: Variable = relationship("Variable", back_populates='entries')
-    datasource: DataSource = relationship("DataSource", back_populates='entries', cascade='all, delete, delete-orphan', single_parent=True)
+    contributors: List['PersonAssociation'] = relationship("PersonAssociation", back_populates='entry', cascade='all, delete, delete-orphan')
+    keywords: List['Keyword'] = relationship("Keyword", back_populates='tagged_entries', secondary="nm_keywords_entries")
+    license: 'License' = relationship("License", back_populates='entries')
+    variable: 'Variable' = relationship("Variable", back_populates='entries')
+    datasource: 'DataSource' = relationship("DataSource", back_populates='entries', cascade='all, delete, delete-orphan', single_parent=True)
     other_versions = relationship("Entry", backref=backref('latest_version', remote_side=[id]))
-    associated_groups: List[EntryGroup] = relationship("EntryGroup", secondary="nm_entrygroups", back_populates='entries')
-    details: List[Detail] = relationship("Detail", back_populates='entry')
+    associated_groups: List['EntryGroup'] = relationship("EntryGroup", secondary="nm_entrygroups", back_populates='entries')
+    details: List['Detail'] = relationship("Detail", back_populates='entry')
 
     # extensions
     io_extension = None
@@ -206,6 +206,10 @@ class Entry(Base):
     def to_dict(self, deep=False, stringify=False) -> dict:
         """
         Return the model as a python dictionary.
+
+        .. versionchanged:: 0.7.4
+
+            The dictionary now contains all persons roles
 
         Parameters
         ----------

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -270,7 +270,7 @@ class Entry(Base):
 
         # update the return dict if there were any updates
         if len(updates) > 0:
-            out.update(dict)
+            out.update(updates)
 
         # lazy loading
         if deep:

--- a/metacatalog/models/person.py
+++ b/metacatalog/models/person.py
@@ -20,6 +20,7 @@ class Person(Base):
     associated.
 
     .. note::
+
         In metatacatalog, an organisation_name is an optional, but
         recommended information. On export to ISO 19115 persons without
         affilated organisations can't be exported. Thus, they should
@@ -80,7 +81,7 @@ class Person(Base):
     attribution = Column(String(1024))
 
     # relationships
-    entries: List[Entry] = relationship("PersonAssociation", back_populates='person')
+    entries: List['Entry'] = relationship("PersonAssociation", back_populates='person')
 
     def to_dict(self, deep=False) -> dict:
         """To dict
@@ -251,7 +252,7 @@ class PersonAssociation(Base):
     # relationships
     role: PersonRole = relationship("PersonRole", back_populates='persons_with_role')
     person: Person = relationship("Person", back_populates='entries')
-    entry: Entry = relationship("Entry", back_populates='contributors')
+    entry: 'Entry' = relationship("Entry", back_populates='contributors')
 
     def to_dict(self, deep=False) -> dict:
         """

--- a/metacatalog/models/person.py
+++ b/metacatalog/models/person.py
@@ -1,3 +1,7 @@
+from typing import TYPE_CHECKING, List
+if TYPE_CHECKING:
+    from metacatalog.models import Entry
+
 from uuid import uuid4
 
 from sqlalchemy import Column, ForeignKey, CheckConstraint
@@ -76,7 +80,7 @@ class Person(Base):
     attribution = Column(String(1024))
 
     # relationships
-    entries = relationship("PersonAssociation", back_populates='person')
+    entries: List[Entry] = relationship("PersonAssociation", back_populates='person')
 
     def to_dict(self, deep=False) -> dict:
         """To dict
@@ -245,9 +249,9 @@ class PersonAssociation(Base):
     order = Column(Integer, nullable=False)
 
     # relationships
-    role = relationship("PersonRole", back_populates='persons_with_role')
-    person = relationship("Person", back_populates='entries')
-    entry = relationship("Entry", back_populates='contributors')
+    role: PersonRole = relationship("PersonRole", back_populates='persons_with_role')
+    person: Person = relationship("Person", back_populates='entries')
+    entry: Entry = relationship("Entry", back_populates='contributors')
 
     def to_dict(self, deep=False) -> dict:
         """

--- a/metacatalog/test/test_todict_fromdict.py
+++ b/metacatalog/test/test_todict_fromdict.py
@@ -1,0 +1,57 @@
+import pytest
+
+import pandas as pd
+import numpy as np
+from numpy.testing import assert_array_almost_equal
+from metacatalog import api
+from ._util import connect
+
+
+def check_to_dict_persons(session):
+    """
+    Find an Entry with Persons with different roles.
+    Check `Entry.to_dict()` output to behave as expected
+    for different person roles.
+    """
+    # find entry
+    entry = api.find_entry(session, title="Entry with some extra Person roles")[0]
+
+    # Entry.to_dict()
+    entry_dict = entry.to_dict()
+
+    # check that the different roles are correctly displayed in Entry.to_dict()
+    assert entry_dict['author']['last_name'] == 'Reeves'
+    assert len(entry_dict['authors']) == 2
+    assert len(entry_dict['pointOfContact']) == 2
+    assert entry_dict['rightsHolder'][0]['last_name'] == 'Master'
+
+    return True
+
+@pytest.mark.depends(on=['add_find'], name='dict_methods')
+def test_fromdict_todict():
+    """
+    Currently tests Entry.to_dict() and Entry.from_dict()
+    """
+    # get a session
+    session = connect(mode='session')
+
+    # add an Entry with different Person roles associated to it
+    entry = api.add_entry(session,
+                          title="Entry with some extra Person roles",
+                          author='Reeves',
+                          location="SRID=4326;POINT (29 28)",
+                          variable=1,
+                          license='ODbL'
+                          )
+
+    # add Homer Simpson as coAuthor
+    api.add_persons_to_entries(session, [entry], ['Simpson'], ['coAuthor'], [2])
+
+    # Marie Curie and David Edward Hughes as pointOfContact
+    api.add_persons_to_entries(session, [entry], ['Curie', 'Hughes'], ['pointOfContact', 'pointOfContact'], [3, 3])
+
+    # Location Master as rightsHolder
+    api.add_persons_to_entries(session, [entry], ['Master'], ['rightsHolder'], [4])
+
+    # run single tests
+    assert check_to_dict_persons(session)

--- a/metacatalog/test/test_todict_fromdict.py
+++ b/metacatalog/test/test_todict_fromdict.py
@@ -41,7 +41,7 @@ def check_from_dict(session):
     # currently, if 'id' is in entry_dict, a NotImplementedError is raised
     with pytest.raises(NotImplementedError):
         # run Entry.from_dict()
-        entry_fromdict = Entry.from_dict(session, entry_dict)
+        entry_fromdict = Entry.from_dict(session=session, data=entry_dict)
 
     return True
 

--- a/metacatalog/test/test_todict_fromdict.py
+++ b/metacatalog/test/test_todict_fromdict.py
@@ -1,9 +1,7 @@
 import pytest
 
-import pandas as pd
-import numpy as np
-from numpy.testing import assert_array_almost_equal
 from metacatalog import api
+from metacatalog.models import Entry
 from ._util import connect
 
 
@@ -26,6 +24,27 @@ def check_to_dict_persons(session):
     assert entry_dict['rightsHolder'][0]['last_name'] == 'Master'
 
     return True
+
+
+def check_from_dict(session):
+    """
+    Check Entry.from_dict().
+    This currently just checks that `Entry.from_dict(entry.to_dict())`
+    raises a NotImplementedError, as 'id' is in the input dict. 
+    """
+    # find entry
+    entry = api.find_entry(session, title="Entry with some extra Person roles")[0]
+
+    # Entry.to_dict()
+    entry_dict = entry.to_dict()
+
+    # currently, if 'id' is in entry_dict, a NotImplementedError is raised
+    with pytest.raises(NotImplementedError):
+        # run Entry.from_dict()
+        entry_fromdict = Entry.from_dict(session, entry_dict)
+
+    return True
+
 
 @pytest.mark.depends(on=['add_find'], name='dict_methods')
 def test_fromdict_todict():
@@ -55,3 +74,4 @@ def test_fromdict_todict():
 
     # run single tests
     assert check_to_dict_persons(session)
+    assert check_from_dict(session)


### PR DESCRIPTION
This closes #252

It adds `FutureWarnings` to `Entry_from_dict` and `api.find_entry` as well as adds the `coauthor` argument as a replacement for `contributor`.

**Only merge after #248 has been merged**