### PR TITLE
get_uuid() can return ImmutableResultSets, updates to ImmutableResultSet.uuid/uuids

### DIFF
--- a/metacatalog/api/catalog.py
+++ b/metacatalog/api/catalog.py
@@ -4,13 +4,17 @@ The catalog API offers application wide endpoints that are not bound to a
 specific API action or model
 
 """
+from typing import Union
+
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.exc import NoResultFound
 
 from metacatalog import api
 from metacatalog.util.logging import get_logger
+from metacatalog.util.results import ImmutableResultSet
+from metacatalog.models import Entry, EntryGroup, Keyword, Person
 
-def get_uuid(session: Session, uuid: str, not_found='raise'):
+def get_uuid(session: Session, uuid: str, as_result: bool=False, not_found: str='raise') -> Union[Entry, EntryGroup, Keyword, Person, ImmutableResultSet, None]:
     """
     Return the Metacatalog object of given
     version 4 UUID. The supported objects are:
@@ -25,17 +29,47 @@ def get_uuid(session: Session, uuid: str, not_found='raise'):
     .. versionchanged:: 0.2.7
         Now, also :class:`Persons <metacatalog.model.Person` can be
         found by UUID
+    
+    .. versionchanged:: 0.7.5
+        Found Entry and EntryGroup can be returned as ImmutableResultSet
+        now.
+
+    Parameters
+    ----------
+    session : sqlalchemy.Session
+        SQLAlchemy session connected to the database.
+    uuid : str
+        Find by version 4 UUID.
+    as_result : bool
+        .. versionadded:: 0.7.5
+        
+        If True, the found Entry or Entrygroup will be merged into a
+        :class:`ImmutableResultSet <metacatalog.util.results.ImmutableResultSet>`.
+        Ignored for matched Keyword and Person.
+        Defaults to False.
+
+    Returns
+    -------
+    record : Entry, EntryGroup, Keyword, Person, ImmutableResultSet, None
+        Matched Entry, EntryGroup, Keyword, Person or ImmutableResultSet.
+        If no match was found, None is returned.
 
     """
     # check if an Entry exists
     entry = api.find_entry(session, uuid=uuid)
     if entry is not None:
-        return entry
+        if as_result:
+            return ImmutableResultSet(entry)
+        else:
+            return entry
 
     # check if Entrygroup exists
     group = api.find_group(session, uuid=uuid)
     if group is not None:
-        return group
+        if as_result:
+            return ImmutableResultSet(group)
+        else:
+            return group
 
     # check if a Person exists
     person = api.find_person(session, uuid=uuid)

--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -243,7 +243,19 @@ class ImmutableResultSet:
         associated to this result.
         """
         return len(self._members) == 0 and self.group is None
-
+    
+    @property
+    def uuid(self) -> str:
+        """
+        .. versionadded 0.7.5
+        Returns the first uuid in the ImmutableResultSet.
+        This is the uuid of the base group, if it exists or the uuid
+        of the first member. As uuids of members are sorted in 
+        ``uuids(self)``, ``self.uuids[0]`` always returns the same
+        uuid for the same ImmutableResultSet.
+        """
+        return self.uuids[0]
+    
     @property
     def uuids(self):
         """
@@ -252,18 +264,19 @@ class ImmutableResultSet:
         .. versionchanged:: 0.6.8
             If a member in in _members is an ImmutableResultSet, call this
             method recursively
+        .. versionchanged:: 0.7.5
+            Members of ImmutableResultSets cannot be ImmutableResultSets
+            again, reverted recursive method call from version 0.6.8
 
         """
         # get the group uuid
         uuids = [self.group.uuid] if self.group is not None else []
 
+        # sort all uuid to preserve the order
+        members_uuids = sorted([e.uuid for e in self._members if hasattr(e, 'uuid')])
+        
         # expand member uuids
-        uuids.extend([e.uuid for e in self._members if hasattr(e, 'uuid')])
-
-        # if member is a ImmutableResultSet again, call this method recursicely
-        for m in self._members:
-            if hasattr(m, 'uuids'):
-                uuids.extend(m.uuids)
+        uuids.extend(members_uuids)
 
         return uuids
 

--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -127,9 +127,11 @@ class ImmutableResultSet:
         Expand this Entry to all siblings.
 
         .. versionchanged:: 0.3.8
+
             Split datasets are now nested
         
         .. versionchanged:: 0.6.11
+        
             the calling entry is now always part of the expansion set.
 
         """
@@ -148,6 +150,7 @@ class ImmutableResultSet:
         Return a set of entries to remove duplicates
 
         .. versionchanged:: 0.3.8
+
             Can now handle nested ResultSets
 
         """
@@ -174,6 +177,7 @@ class ImmutableResultSet:
         itself will be returned
 
         .. versionchanged:: 0.3.8
+
             get can now handle nested ImmutableResultSets
 
         Parameters
@@ -241,6 +245,7 @@ class ImmutableResultSet:
 
         Returns True if there is no :class:`Entry <metacatalog.models.Entry>`
         associated to this result.
+
         """
         return len(self._members) == 0 and self.group is None
     
@@ -248,11 +253,13 @@ class ImmutableResultSet:
     def uuid(self) -> str:
         """
         .. versionadded 0.7.5
+
         Returns the first uuid in the ImmutableResultSet.
         This is the uuid of the base group, if it exists or the uuid
         of the first member. As uuids of members are sorted in 
         ``uuids(self)``, ``self.uuids[0]`` always returns the same
         uuid for the same ImmutableResultSet.
+
         """
         return self.uuids[0]
     
@@ -262,9 +269,12 @@ class ImmutableResultSet:
         Return all uuids that form this result set
 
         .. versionchanged:: 0.6.8
+
             If a member in in _members is an ImmutableResultSet, call this
             method recursively
+
         .. versionchanged:: 0.7.5
+
             Members of ImmutableResultSets cannot be ImmutableResultSets
             again, reverted recursive method call from version 0.6.8
 
@@ -286,6 +296,7 @@ class ImmutableResultSet:
         .. versionadded:: 0.3.8
         
         Return all checksums of all members
+
         """
         # get the group checksum
         checksums = [self.group.checksum] if self.group is not None else []
@@ -306,7 +317,8 @@ class ImmutableResultSet:
         The checksum is the md5 hash of all contained member checksums.
 
         .. versionchanged:: 0.3.8
-            now hasing md5 of members instead of uuids
+
+            now hashing md5 of members instead of uuids
 
         """
         return hashlib.md5(''.join(self.checksums).encode()).hexdigest()
@@ -315,6 +327,7 @@ class ImmutableResultSet:
         """
         Check if the given Entry or EntryGroup is 
         present in this result set
+
         """
         return uuid in self.uuids
 
@@ -323,6 +336,7 @@ class ImmutableResultSet:
         Get a short unified version of the results.
 
         .. todo:: 
+
             the list of used keys is hardcoded and should
             depend on the variable / group type or be completely
             dynamic
@@ -339,11 +353,13 @@ class ImmutableResultSet:
         Generate a full dictionary output of this result set.
 
         .. versionchanged:: 0.6.8
+
             Parameter `orient` added. The default value is `'dict'`, which returns
             a dictionary with unique keys.
             The value `'uuids'` will give the dictionary with uuids as keys, this
             should make it easier to i.e. loop over the uuids / entities of an
             ImmutableResultSet.
+
         """
         # first get a list of all available keys
         keys = []
@@ -366,6 +382,7 @@ class ImmutableResultSet:
     def get_data(self, verbose=False, merge=False, **kwargs) -> dict:
         """
         Return the data as a checksum indexed dict
+
         """
         # output container
         data = dict()
@@ -494,6 +511,7 @@ class ResultList:
     def _filter_set(self, members: List[ImmutableResultSet]) -> List[ImmutableResultSet]:
         """
         Uses the checksum of each member to create a set od ImmutableResultSet
+
         """
         # extract the checksums
         md5s = [m.checksum for m in members]
@@ -533,6 +551,7 @@ class ResultList:
         string in the metadata. The first occurence is passed.
 
         .. note::
+
             This method is quite slow, due to the type casting, lazy-loading from
             database and the recursive behavior. If you want to search by MD5 hash
             you can directly use the ResultSet.checksums property, which preserves


### PR DESCRIPTION
New Parameter `as_result` for function `catalog.get_uuid()`.

`ImmutableResultSet.uuids` returns sorted member uuids now.

`ImmutableResultSet.uuid` returns the first uuid of members in the ImmutableResultSet, if a base group exist, this is the first uuid in the IRS. As  `ImmutableResultSet.uuids` now returns sorted member uuids, `uuids[0]` is now always the same uuid for ImmutableResultSets containing the same members.