### PR TITLE
Add Cli registration interface for extensions

### DIFF
--- a/metacatalog/command_line.py
+++ b/metacatalog/command_line.py
@@ -98,6 +98,12 @@ def main():
     migration_parser.add_argument('--message', '-m', type=str, help="Optional revision message. Only used for revision command")
     migration_parser.set_defaults(func=migrate)
 
+    # check extensions for CLI registers
+    from metacatalog.ext import EXTENSIONS
+    for extension in EXTENSIONS.values():
+        if hasattr(extension, 'init_cli'):
+            extension.init_cli(subparsers=subparsers, defaults=default_options)
+
     # parse the arguments
     args = parser.parse_args()
 

--- a/metacatalog/ext/__init__.py
+++ b/metacatalog/ext/__init__.py
@@ -11,7 +11,7 @@ it permanently using the :func:`activate_extension`
 """
 from .base import MetacatalogExtensionInterface
 
-EXTENSIONS = dict()
+EXTENSIONS: dict[str, MetacatalogExtensionInterface] = dict()
 
 
 def extension(name: str, interface: MetacatalogExtensionInterface =None):

--- a/metacatalog/ext/__init__.py
+++ b/metacatalog/ext/__init__.py
@@ -9,9 +9,10 @@ imported, you can add it using the :func:`extension` function, or add
 it permanently using the :func:`activate_extension`
 
 """
+from typing import Dict
 from .base import MetacatalogExtensionInterface
 
-EXTENSIONS: dict[str, MetacatalogExtensionInterface] = dict()
+EXTENSIONS: Dict[str, MetacatalogExtensionInterface] = dict()
 
 
 def extension(name: str, interface: MetacatalogExtensionInterface =None):

--- a/metacatalog/ext/base.py
+++ b/metacatalog/ext/base.py
@@ -58,6 +58,9 @@ the old ``__init__`` functions is copied and executed inside the new
 
 """
 import abc
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from argparse import _SubParsersAction, ArgumentParser
 
 
 class MetacatalogExtensionInterface(abc.ABC):
@@ -77,5 +80,36 @@ class MetacatalogExtensionInterface(abc.ABC):
         pass
 
     @classmethod
-    def init_cli(cls):
+    def init_cli(cls, subparsers: _SubParsersAction[ArgumentParser], defaults: ArgumentParser) -> None:
+        """
+        Add a new :class:`ArgumentParser <argparse.ArgumentParser>` to the metacatalog CLI.
+        The main CLI argument parser will call the ``init_cli`` class method of all active
+        extensions and pass the main subparser to the init function. The second argument
+        is the :class:`ArgumentParser <argparse.ArgumentParser>`, which holds the default
+        arguments, that should affect all CLI functions.
+
+        Example
+        -------
+
+        .. code-block:: Python
+
+            from metacatalog.ext import MetacatalogExtensionInterface
+
+            class MyExt(MetacatalogExtensionInterface):
+                @classmethod
+                def init_extension(cls):
+                    pass
+                
+                @classmethod
+                def cli(cls, args):
+                    if not args.quiet:
+                        print(args.foo.upper())
+                    
+                @classmethod
+                def init_cli(subparsers, defaults):
+                    myparser = subparsers.add_parser('foobar', parents=[defaults], help="Just a foobar parser")
+                    myparser.add_argument('foo', type="str", help="A nonsense argument")
+                    myparser.set_defaults(func=MyExt.cli)
+
+        """
         return None

--- a/metacatalog/ext/base.py
+++ b/metacatalog/ext/base.py
@@ -80,7 +80,7 @@ class MetacatalogExtensionInterface(abc.ABC):
         pass
 
     @classmethod
-    def init_cli(cls, subparsers: _SubParsersAction[ArgumentParser], defaults: ArgumentParser) -> None:
+    def init_cli(cls, subparsers: '_SubParsersAction[ArgumentParser]', defaults: 'ArgumentParser') -> None:
         """
         Add a new :class:`ArgumentParser <argparse.ArgumentParser>` to the metacatalog CLI.
         The main CLI argument parser will call the ``init_cli`` class method of all active

--- a/metacatalog/ext/base.py
+++ b/metacatalog/ext/base.py
@@ -75,3 +75,7 @@ class MetacatalogExtensionInterface(abc.ABC):
     @abc.abstractclassmethod
     def init_extension(cls):
         pass
+
+    @classmethod
+    def init_cli(cls):
+        return None

--- a/metacatalog/models/datasource.py
+++ b/metacatalog/models/datasource.py
@@ -1,6 +1,10 @@
+from typing import Union, TYPE_CHECKING
+if TYPE_CHECKING:
+    from metacatalog.models import Entry
 import json
 from functools import wraps
 from datetime import datetime as dt
+from datetime import timedelta
 
 from sqlalchemy import Column, ForeignKey, CheckConstraint
 from sqlalchemy import Integer, String, DateTime, Numeric
@@ -52,9 +56,9 @@ class DataSourceType(Base):
     description = Column(String)
 
     # relationships
-    sources = relationship("DataSource", back_populates='type')
+    sources: list['DataSource'] = relationship("DataSource", back_populates='type')
 
-    def to_dict(self, deep=False) -> dict:
+    def to_dict(self, deep: bool = False) -> dict:
         """
         Return the model as a python dictionary.
 
@@ -88,7 +92,7 @@ class DataSourceType(Base):
 
         return d
 
-    def __str__(self):
+    def __str__(self) -> str:
         return '%s data source <ID=%d>' % (self.name, self.id)
 
 
@@ -123,10 +127,10 @@ class DataType(Base):
     description = Column(String, nullable=True)
 
     # relationships
-    sources = relationship("DataSource", back_populates='datatype')
-    children = relationship("DataType", backref=backref('parent', remote_side=[id]))
+    sources: list['DataSource'] = relationship("DataSource", back_populates='datatype')
+    children: list['DataType'] = relationship("DataType", backref=backref('parent', remote_side=[id]))
 
-    def to_dict(self, deep=False) -> dict:
+    def to_dict(self, deep: bool = False) -> dict:
         """
         Return the model as a python dictionary.
 
@@ -169,7 +173,7 @@ class DataType(Base):
 
         return d
 
-    def parent_list(self):
+    def parent_list(self) -> list['DataType']:
         """
         Returns an inheritance tree for the current datatype.
         If the list is empty, the current datatype is a
@@ -186,7 +190,7 @@ class DataType(Base):
 
         return parents
 
-    def children_list(self):
+    def children_list(self) -> list['DataType']:
         """
         Returns an dependency tree for the current datatype.
         If the list is empty, there are no child (inheriting)
@@ -258,7 +262,7 @@ class TemporalScale(Base):
     support = Column(Numeric, CheckConstraint('support >= 0'), nullable=False, default=1.0)
 
     # relationships
-    sources = relationship("DataSource", back_populates='temporal_scale')
+    sources: list['DataSource'] = relationship("DataSource", back_populates='temporal_scale')
 
     def __init__(self, *args, **kwargs):
         # handle resoultion
@@ -274,30 +278,30 @@ class TemporalScale(Base):
         super(TemporalScale, self).__init__(*args, **kwargs)
 
     @property
-    def resolution_timedelta(self):
+    def resolution_timedelta(self) -> pd.Timedelta:
         return pd.to_timedelta(self.resolution)
 
     @resolution_timedelta.setter
-    def resolution_timedelta(self, delta):
+    def resolution_timedelta(self, delta: Union[str, float, timedelta]):
         self.resolution = pd.to_timedelta(delta).isoformat()
 
     @property
-    def support_timedelta(self):
+    def support_timedelta(self) -> pd.Timedelta:
         return self.resolution_timedelta / 2
 
     @resolution_timedelta.setter
-    def support_timedelta(self, delta):
+    def support_timedelta(self, delta: Union[str, float, timedelta]):
         self.support = pd.to_timedelta(delta) / self.resolution_timedelta
 
     @property
-    def extent(self):
+    def extent(self) -> timedelta:
         return [self.observation_start, self.observation_end]
 
     @extent.setter
-    def extent(self, extent):
+    def extent(self, extent: list[dt, dt]):
         self.observation_start, self.observation_end = extent
 
-    def to_dict(self, deep=False) -> dict:
+    def to_dict(self, deep: bool = False) -> dict:
         """
         Return the model as a python dictionary.
 
@@ -370,7 +374,7 @@ class SpatialScale(Base):
     support = Column(Numeric, CheckConstraint('support >= 0'), nullable=False, default=1.0)
 
     # relationships
-    sources = relationship("DataSource", back_populates='spatial_scale')
+    sources: list['DataSource'] = relationship("DataSource", back_populates='spatial_scale')
 
     @property
     def extent_shape(self):
@@ -392,7 +396,7 @@ class SpatialScale(Base):
             return '%d km' % (int((self.support * self.resolution) / 1000))
         return '%.1f m' % (self.support * self.resolution)
 
-    def to_dict(self, deep=False) -> dict:
+    def to_dict(self, deep: bool = False) -> dict:
         """
         Return the model as a python dictionary.
 
@@ -485,17 +489,17 @@ class DataSource(Base):
     lastUpdate = Column(DateTime, default=dt.utcnow, onupdate=dt.utcnow)
 
     # relationships
-    entries = relationship("Entry", back_populates='datasource')
-    type = relationship("DataSourceType", back_populates='sources')
-    datatype = relationship("DataType", back_populates='sources')
-    temporal_scale = relationship("TemporalScale", back_populates='sources')
-    spatial_scale = relationship("SpatialScale", back_populates='sources')
+    entries: list['Entry'] = relationship("Entry", back_populates='datasource')
+    type: 'DataSourceType' = relationship("DataSourceType", back_populates='sources')
+    datatype: 'DataType' = relationship("DataType", back_populates='sources')
+    temporal_scale: 'TemporalScale' = relationship("TemporalScale", back_populates='sources')
+    spatial_scale: 'SpatialScale' = relationship("SpatialScale", back_populates='sources')
 
     @classmethod
-    def is_valid(cls, ds):
+    def is_valid(cls, ds: 'DataSource') -> bool:
         return hasattr(ds, 'path') and isinstance(ds, DataSource)
 
-    def to_dict(self, deep=False) -> dict:
+    def to_dict(self, deep: bool = False) -> dict:
         """To dict
 
         Return the model as a python dictionary.
@@ -558,7 +562,7 @@ class DataSource(Base):
         else:
             return json.loads(self.args)
 
-    def save_args_from_dict(self, args_dict, commit=False):
+    def save_args_from_dict(self, args_dict: dict, commit: bool = False):
         """
         Save all given keyword arguments to the database.
         These are passed to the importer/adder functions as ``**kwargs``.
@@ -590,7 +594,7 @@ class DataSource(Base):
                 session.rollback()
                 raise e
 
-    def create_scale(self, resolution, extent, support, scale_dimension, commit=False):
+    def create_scale(self, resolution, extent, support, scale_dimension, commit: bool = False):
         """
         Create a new scale for the dataset
         """

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -205,7 +205,7 @@ class Entry(Base):
     io_extension = None
     io_interface = None
 
-    def to_dict(self, deep=False, stringify=False) -> dict:
+    def to_dict(self, deep: bool = False, stringify: bool = False) -> dict:
         """
         Return the model as a python dictionary.
 


### PR DESCRIPTION
This PR closes #263
@AlexDo1 can you check this enhancement with an extra branch of the ISO extension? 
There is an example in the docstring. Using extensions does only work for the CLI, if the extensions are activated, which in turn is only possible if there is an importable path to the class. Hence it does not work from a notebook and I did not check the code in action...