### PR TITLE
As Entry.location is nullable, Entry.location_shape can also be Null

### DIFF
--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -5,6 +5,7 @@ one type of environmental variable. It can hold a reference and interface to the
 If a supported data format is used, Entry can load the data.
 
 """
+from __future__ import annotations
 from typing import List, Dict, Union, TYPE_CHECKING
 if TYPE_CHECKING:
     from metacatalog.models import License, PersonAssociation, Person, Variable, EntryGroup, Keyword, Detail, DataSource, PersonRole
@@ -500,8 +501,11 @@ class Entry(Base):
         return [group for group in self.associated_groups if group.type.name.lower() == 'composite']
 
     @property
-    def location_shape(self) -> 'Point':
-        return to_shape(self.location)
+    def location_shape(self) -> 'Point' | None:
+        if self.location:
+            return to_shape(self.location)
+        else:
+            return None
 
     @location_shape.setter
     def location_shape(self, shape):

--- a/metacatalog/models/entry.py
+++ b/metacatalog/models/entry.py
@@ -237,8 +237,6 @@ class Entry(Base):
             title=self.title,
             author=self.author.to_dict(deep=False),
             authors=[a.to_dict(deep=False) for a in self.authors],
-            locationShape=self.location_shape.wkt,
-            location=self.location_shape.wkt,
             variable=self.variable.to_dict(deep=False),
             embargo=self.embargo,
             embargo_end=self.embargo_end,
@@ -250,6 +248,10 @@ class Entry(Base):
         )
 
         # optional relations
+        if self.location:
+            out['locationShape'] = self.location_shape.wkt
+            out['location'] = self.location_shape.wkt
+
         if self.license is not None:
             out['license'] = self.license.to_dict(deep=False)
 


### PR DESCRIPTION
Fixes `Entry.location_shape` and makes `location` parameters optional in `Entry.to_dict()`