### PR TITLE
ISO 19115: put details into field <supplementalInformation>

### DIFF
--- a/metacatalog/ext/standards_export/schemas/iso19115/iso19115-2.j2
+++ b/metacatalog/ext/standards_export/schemas/iso19115/iso19115-2.j2
@@ -276,7 +276,7 @@
             </gmd:extent>
             {% for detail in details %}
             <gmd:supplementalInformation>
-                <gco:CharacterString>detail</gco:CharacterString>
+                <gco:CharacterString>{{detail}}</gco:CharacterString>
             </gmd:supplementalInformation>
             {% endfor %}
         </gmd:MD_DataIdentification>

--- a/metacatalog/ext/standards_export/schemas/iso19115/iso19115-2.j2
+++ b/metacatalog/ext/standards_export/schemas/iso19115/iso19115-2.j2
@@ -160,16 +160,7 @@
             </gmd:citation>
             <gmd:abstract>
                 <gco:CharacterString>
-                Abstract: 
                 {{abstract | indent(16)}}
-
-                {% for details_table in details %}
-                {% if details_table %}
-                Details:
-                {{details_table | indent(16)}}
-
-                {% endif %}
-                {% endfor %}
                 </gco:CharacterString>
             </gmd:abstract>
             {# first author again as pointOfContact (like GFZ) #}
@@ -283,6 +274,11 @@
                     {% endfor %}
                 </gmd:EX_Extent>
             </gmd:extent>
+            {% for detail in details %}
+            <gmd:supplementalInformation>
+                <gco:CharacterString>detail</gco:CharacterString>
+            </gmd:supplementalInformation>
+            {% endfor %}
         </gmd:MD_DataIdentification>
     </gmd:identificationInfo>
     {# TODO: dataQualityInfo (not yet implemented) #}

--- a/metacatalog/ext/standards_export/util.py
+++ b/metacatalog/ext/standards_export/util.py
@@ -244,53 +244,30 @@ def _get_abstract(rs: ImmutableResultSet) -> str:
 def _get_details(rs: ImmutableResultSet) -> List[str]:
     """
     Returns the details of the ImmutableResultSet.
-    Details are currently written to XML as Markdown tables along the abstracts 
-    of ImmutableResultSet members.
 
     Returns
     ----------
     details: list[str]
-        Details as a markdown table, currently also in field <gmd:abstract>, not repeatable.
+        Used for field <gmd:supplementalInformation>, repeatable.
 
     """
     # create list with details_table for all entries in ImmutableResultSet
-    details = []
-    _details = {}
+    details_list = []
 
-    # if there is only one entry in the ImmutableResultSet, a list details is returned by rs.get('authors')
+    # if there is only one entry in the ImmutableResultSet, a list details is returned by rs.get('details')
     if isinstance(rs.get('details'), list):
         for detail_dict in rs.get('details'):
             # nested details
                 if isinstance(detail_dict['value'], dict):
-                    # include top-level detail of nested detail
-                    _details[detail_dict['key']] = detail_dict.copy()
-                    _details[detail_dict['key']]['value'] = 'nested'
+                    # include top-level key of nested detail
+                    details_list.append(f"{detail_dict['key']}: nested")
                     
-                    # remove unwanted key-value pairs
-                    _details[detail_dict['key']] = {key: val for key, val in _details[detail_dict['key']].items() if key in ['value', 'key', 'entry_uuid', 'description']}
-
                     # go for nested details
                     for k, v in detail_dict['value'].items():
-                        expand = {
-                            f"{detail_dict['key']}.{k}": dict(
-                            value=v,
-                            key=detail_dict['key'],
-                            entry_uuid=detail_dict['entry_uuid'],
-                            description=detail_dict.get('description', 'nan')
-                            )
-                        }
-                        _details.update(expand)
-                # un-nested details
+                        details_list.append(f"{detail_dict['key']}.{k}: {v}")
+                # flat details
                 else:
-                    _details[detail_dict['key']] = detail_dict
-                    # remove unwanted key-value pairs
-                    _details[detail_dict['key']] = {key: val for key, val in _details[detail_dict['key']].items() if key in ['value', 'key', 'entry_uuid', 'description']}
-
-        # turn into a transposed dataframe
-        df = pd.DataFrame(_details).T
-
-        # append markdown table to details
-        details.append(df.to_markdown())
+                    details_list.append(f"{detail_dict['key']}: {detail_dict['value']}")
 
     # if there are more than one entries in the ImmutableResultSet, a entry_uuid-indexed dictionary of details is returned
     elif isinstance(rs.get('details'), dict):
@@ -298,37 +275,20 @@ def _get_details(rs: ImmutableResultSet) -> List[str]:
             for detail_dict in entry_details_list:
                 # nested details
                 if isinstance(detail_dict['value'], dict):
-                    # include top-level detail of nested detail
-                    _details[detail_dict['key']] = detail_dict.copy()
-                    _details[detail_dict['key']]['value'] = 'nested'
+                    # include top-level key of nested detail
+                    details_list.append(f"{detail_dict['key']}: nested")
                     
-                    # remove unwanted key-value pairs
-                    _details[detail_dict['key']] = {key: val for key, val in _details[detail_dict['key']].items() if key in ['value', 'key', 'entry_uuid', 'description']}
-
                     # go for nested details
                     for k, v in detail_dict['value'].items():
-                        expand = {
-                            f"{detail_dict['key']}.{k}": dict(
-                            value=v,
-                            key=detail_dict['key'],
-                            entry_uuid=detail_dict['entry_uuid'],
-                            description=detail_dict.get('description', 'nan')
-                            )
-                        }
-                        _details.update(expand)
-                # un-nested details
+                        details_list.append(f"{detail_dict['key']}.{k}: {v}")
+                # flat details
                 else:
-                    _details[detail_dict['key']] = detail_dict
-                    # remove unwanted key-value pairs
-                    _details[detail_dict['key']] = {key: val for key, val in _details[detail_dict['key']].items() if key in ['value', 'key', 'entry_uuid', 'description']}
+                    details_list.append(f"{detail_dict['key']}: {detail_dict['value']}")
 
-            # turn into a transposed dataframe
-            df = pd.DataFrame(_details).T
+    # remove duplicate details
+    details_list = list(set(details_list))
 
-            # append markdown table to details
-            details.append(df.to_markdown())
-
-    return details
+    return details_list
 
 
 def _get_keywords(rs: ImmutableResultSet) -> List[Dict]:

--- a/metacatalog/ext/standards_export/util.py
+++ b/metacatalog/ext/standards_export/util.py
@@ -285,8 +285,8 @@ def _get_details(rs: ImmutableResultSet) -> List[str]:
                 else:
                     details_list.append(f"{detail_dict['key']}: {detail_dict['value']}")
 
-    # remove duplicate details
-    details_list = list(set(details_list))
+    # remove duplicate details, without changing the order (keep top level keys of nested details on top)
+    details_list = list(dict.fromkeys(details_list).keys())
 
     return details_list
 


### PR DESCRIPTION
With this PR, details are no longer stored in the ISO field `<abstract>` but in `<supplementalInformation>` instead.

Closes #266 