### PR TITLE
Fix rs.to_dict(orient='uuids') in the case that rs.group is None

### DIFF
--- a/metacatalog/util/results.py
+++ b/metacatalog/util/results.py
@@ -377,7 +377,7 @@ class ImmutableResultSet:
         
         elif orient.lower() == 'uuids':
             # return dictionary of ImmutableResultSet members indexed by their uuid
-            return {member.uuid: member.to_dict() for member in [self.group, *self._members]}
+            return {member.uuid: member.to_dict() for member in [self.group, *self._members] if hasattr(member, 'to_dict')}
         else:
             raise AttributeError(f"orient = '{orient}' is not supported. Use one of ['dict', 'uuids']")
 


### PR DESCRIPTION
I just stumbled upon an error in #296.

Old code produced an error, as `rs.group` just returns `None` when no group is associated to the `ImmutableResultSet`:
```python
return {member.uuid: member.to_dict() for member in [rs.group, *rs._members]}
```

New code checks if member has attribute `to_dict` before adding it to returned dictionary:
```python
return {member.uuid: member.to_dict() for member in [rs.group, *rs._members] if hasattr(member, 'to_dict')}
```