### PR TITLE
Add to_json method for exporting Entry metadata to JSON

### DIFF
--- a/metacatalog/test/test_todict_fromdict.py
+++ b/metacatalog/test/test_todict_fromdict.py
@@ -3,6 +3,7 @@ import pytest
 from metacatalog import api
 from metacatalog.models import Entry
 from ._util import connect
+import json
 
 
 def check_to_dict_persons(session):
@@ -42,6 +43,35 @@ def check_from_dict(session):
     with pytest.raises(NotImplementedError):
         # run Entry.from_dict()
         entry_fromdict = Entry.from_dict(session=session, data=entry_dict)
+
+    return True
+
+
+def check_to_json(session, tmp_path):
+    """
+    Check Entry.to_json().
+    This also checks if the output is a valid json by trying to load 
+    it with json.load().
+
+    """
+    # test for all entries in test database
+    for entry in api.find_entries(session):
+        # create a temporary file
+        tmp_file = tmp_path / "entry.json"
+
+        # write JSON to the temporary file
+        entry.to_json(path=str(tmp_file))
+
+        # load the JSON from the file, if the JSON is not valid, the test fails with a JSONDecodeError
+
+        with open(tmp_file, 'r') as f:
+            loaded_dict = json.load(f)
+
+    assert loaded_dict['title'] == entry.title
+    assert isinstance(loaded_dict[id], int)
+    assert isinstance(loaded_dict['author'], dict)
+    assert isinstance(loaded_dict['authors'], list)
+    assert isinstance(loaded_dict['embargo'], bool)
 
     return True
 

--- a/metacatalog/test/test_todict_fromdict.py
+++ b/metacatalog/test/test_todict_fromdict.py
@@ -55,7 +55,7 @@ def check_to_json(session, tmp_path):
 
     """
     # test for all entries in test database
-    for entry in api.find_entries(session):
+    for entry in api.find_entry(session):
         # create a temporary file
         tmp_file = tmp_path / "entry.json"
 
@@ -68,7 +68,7 @@ def check_to_json(session, tmp_path):
             loaded_dict = json.load(f)
 
     assert loaded_dict['title'] == entry.title
-    assert isinstance(loaded_dict[id], int)
+    assert isinstance(loaded_dict['id'], int)
     assert isinstance(loaded_dict['author'], dict)
     assert isinstance(loaded_dict['authors'], list)
     assert isinstance(loaded_dict['embargo'], bool)
@@ -77,7 +77,7 @@ def check_to_json(session, tmp_path):
 
 
 @pytest.mark.depends(on=['add_find'], name='dict_methods')
-def test_fromdict_todict():
+def test_fromdict_todict(tmp_path):
     """
     Currently tests Entry.to_dict() and Entry.from_dict()
     """
@@ -105,3 +105,4 @@ def test_fromdict_todict():
     # run single tests
     assert check_to_dict_persons(session)
     assert check_from_dict(session)
+    assert check_to_json(session, tmp_path=tmp_path)


### PR DESCRIPTION
I decided to go for a new method `Entry.to_json` for serializable entry-to-json-export. I think that's easier than trying to fix the `export` extension.
The created json should be serializable as I convert non-json datatypes to json datatypes with a custom JsonEncoder.

If we want to go for another way, we can revert this, but for now this should work.